### PR TITLE
feat: add .5-step highlight/shadow tone mappings to TONE_VALUES

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -106,11 +106,17 @@ export const TAG_ID_DEVELOPMENT_DYNAMIC_RANGE = 0x1403
 export const TAG_ID_HIGHLIGHT_TONE = 0x1041
 export const TONE_VALUES = {
   '-64': '+4',
+  '-56': '+3.5',
   '-48': '+3',
+  '-40': '+2.5',
   '-32': '+2',
+  '-24': '+1.5',
   '-16': '+1',
+  '-8': '+0.5',
   '0': '0',
+  '8': '-0.5',
   '16': '-1',
+  '24': '-1.5',
   '32': '-2',
 } as const
 


### PR DESCRIPTION
Added .5-step tone mappings (-56:+3.5, -40:+2.5, -24:+1.5, -8:+0.5, 8:-0.5, 24:-1.5) to TONE_VALUES
These values have been tested and validated on actual photos.
No breaking changes introduced.